### PR TITLE
JEAP-7398 Route jeap-frontend-license-checker to Tooling & Registries

### DIFF
--- a/docs/_categories
+++ b/docs/_categories
@@ -87,6 +87,7 @@ jeap-central-publishing-maven-plugin             = tool
 jeap-opensearch-index-type-registry-maven-plugin = tool
 jeap-rewrite-recipes                             = tool
 jeap-license-template                            = tool
+jeap-frontend-license-checker                    = tool
 jeap-message-type-registry                       = tool
 jeap-archive-type-registry                       = tool
 jeap-test-message-type-registry                  = tool


### PR DESCRIPTION
`jeap-frontend-license-checker` ships docs, so auto-discovery picks it up as its own section — but it had no line in `docs/_categories`. The fallback for a repo whose name does not contain `starter` is Libraries, so that is where it was listed.

It is a tool, so route it to `tooling`, next to `jeap-license-template`:

```
jeap-frontend-license-checker                    = tool
```

## Verification

Ran `prepare-docs.sh` from the site repo against this manifest with `jeap-frontend-license-checker`, `jeap-cli` and `jeap-audit` as fixture sections:

```
building-blocks/libraries/jeap-audit
building-blocks/tooling/jeap-cli
building-blocks/tooling/jeap-frontend-license-checker
```

It now lands under **Tooling & Registries**; the unrouted control (`jeap-audit`, explicitly a `library`) is unaffected.

Manifest-only change — no doc content is touched, and the routing line's position in the file has no effect on sidebar order (that comes from the processing order of the sections).
